### PR TITLE
Revert Login before Pull

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Login
-      run: >
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build
       run: >
         docker build
@@ -30,9 +27,8 @@ jobs:
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}
       run: >
-        docker push $CR_REPOSITORY
-    - name: Logout
-      run: >
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
+        docker push $CR_REPOSITORY &&
         docker logout ghcr.io
 
   gcc:
@@ -43,9 +39,6 @@ jobs:
         version: [8, 9, 10]
     steps:
     - uses: actions/checkout@v2
-    - name: Login
-      run: >
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build
       run: >
         docker build
@@ -59,9 +52,8 @@ jobs:
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}
       run: >
-        docker push $CR_REPOSITORY
-    - name: Logout
-      run: >
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
+        docker push $CR_REPOSITORY &&
         docker logout ghcr.io
 
   clang:
@@ -72,9 +64,6 @@ jobs:
         version: [9, 10, 11]
     steps:
     - uses: actions/checkout@v2
-    - name: Login
-      run: >
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build
       run: >
         docker build
@@ -88,9 +77,8 @@ jobs:
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}
       run: >
-        docker push $CR_REPOSITORY
-    - name: Logout
-      run: >
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
+        docker push $CR_REPOSITORY &&
         docker logout ghcr.io
 
   cuda:
@@ -98,9 +86,6 @@ jobs:
     needs: base
     steps:
     - uses: actions/checkout@v2
-    - name: Login
-      run: >
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build
       run: >
         docker build
@@ -113,9 +98,8 @@ jobs:
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}
       run: >
-        docker push $CR_REPOSITORY
-    - name: Logout
-      run: >
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
+        docker push $CR_REPOSITORY &&
         docker logout ghcr.io
 
   clang-cuda:
@@ -126,9 +110,6 @@ jobs:
         version: [11]
     steps:
     - uses: actions/checkout@v2
-    - name: Login
-      run: >
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build
       run: >
         docker build
@@ -143,9 +124,8 @@ jobs:
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}
       run: >
-        docker push $CR_REPOSITORY
-    - name: Logout
-      run: >
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
+        docker push $CR_REPOSITORY &&
         docker logout ghcr.io
 
   hip:
@@ -153,9 +133,6 @@ jobs:
     needs: base
     steps:
     - uses: actions/checkout@v2
-    - name: Login
-      run: >
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build
       run: >
         docker build
@@ -168,9 +145,8 @@ jobs:
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}
       run: >
-        docker push $CR_REPOSITORY
-    - name: Logout
-      run: >
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
+        docker push $CR_REPOSITORY &&
         docker logout ghcr.io
 
   hpx:
@@ -181,9 +157,6 @@ jobs:
         base: [gcc-10]
     steps:
     - uses: actions/checkout@v2
-    - name: Login
-      run: >
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build
       run: >
         docker build
@@ -198,9 +171,8 @@ jobs:
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}
       run: >
-        docker push $CR_REPOSITORY
-    - name: Logout
-      run: >
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
+        docker push $CR_REPOSITORY &&
         docker logout ghcr.io
 
   atlas:
@@ -211,9 +183,6 @@ jobs:
         base: [gcc-9]
     steps:
     - uses: actions/checkout@v2
-    - name: Login
-      run: >
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build
       run: >
         docker build
@@ -228,7 +197,6 @@ jobs:
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}
       run: >
-        docker push $CR_REPOSITORY
-    - name: Logout
-      run: >
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
+        docker push $CR_REPOSITORY &&
         docker logout ghcr.io


### PR DESCRIPTION
Containers can now be downloaded without login, so this is not necessary anymore.