### PR TITLE
update CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         --build-arg BUILDKIT_INLINE_CACHE=1
         --tag $CR_REPOSITORY:base
         --build-arg REPOSITORY=$CR_REPOSITORY
+        --build-arg CMAKE_VERSION=3.21.2
         base
     - name: Push
       if: ${{ github.event_name == 'push' && github.repository == 'GridTools/gridtools-docker' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,4 +281,3 @@ jobs:
         echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
         docker push $CR_REPOSITORY:${{ matrix.base }}-parmetis &&
         docker logout ghcr.io
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,3 +281,4 @@ jobs:
         echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
         docker push $CR_REPOSITORY:${{ matrix.base }}-parmetis &&
         docker logout ghcr.io
+

--- a/atlas/Dockerfile
+++ b/atlas/Dockerfile
@@ -23,11 +23,14 @@ RUN cd /tmp && \
     rm -rf /tmp/*
 
 
+# patch atlas
 ARG ATLAS_VERSION=0.20.1
 RUN cd /tmp && \
     wget -q https://github.com/ecmwf/atlas/archive/${ATLAS_VERSION}.tar.gz && \
     tar xzf ${ATLAS_VERSION}.tar.gz && \
     cd atlas-${ATLAS_VERSION} && \
+    sed -i '13 i #include <string>' ./src/atlas/grid/Spacing.h && \
+    head -n 100 ./src/atlas/grid/Spacing.h && \
     mkdir build && cd build && \
     ecbuild .. && \
     make -j$(nproc) install && \

--- a/atlas/Dockerfile
+++ b/atlas/Dockerfile
@@ -23,7 +23,6 @@ RUN cd /tmp && \
     rm -rf /tmp/*
 
 
-# patch atlas: add missing include <string>
 ARG ATLAS_VERSION=0.26.0
 RUN cd /tmp && \
     wget -q https://github.com/ecmwf/atlas/archive/${ATLAS_VERSION}.tar.gz && \

--- a/atlas/Dockerfile
+++ b/atlas/Dockerfile
@@ -23,14 +23,13 @@ RUN cd /tmp && \
     rm -rf /tmp/*
 
 
-# patch atlas
+# patch atlas: add missing include <string>
 ARG ATLAS_VERSION=0.20.1
 RUN cd /tmp && \
     wget -q https://github.com/ecmwf/atlas/archive/${ATLAS_VERSION}.tar.gz && \
     tar xzf ${ATLAS_VERSION}.tar.gz && \
     cd atlas-${ATLAS_VERSION} && \
     sed -i '13 i #include <string>' ./src/atlas/grid/Spacing.h && \
-    head -n 100 ./src/atlas/grid/Spacing.h && \
     mkdir build && cd build && \
     ecbuild .. && \
     make -j$(nproc) install && \

--- a/atlas/Dockerfile
+++ b/atlas/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE
 FROM ${REPOSITORY}:${BASE}
 LABEL maintainer="Felix Thaler <thaler@cscs.ch>"
 
-ARG ECBUILD_VERSION=3.3.2
+ARG ECBUILD_VERSION=3.6.3
 RUN cd /tmp && \
     wget -q https://github.com/ecmwf/ecbuild/archive/${ECBUILD_VERSION}.tar.gz && \
     tar xzf ${ECBUILD_VERSION}.tar.gz && \
@@ -12,7 +12,7 @@ RUN cd /tmp && \
 
 ENV PATH=/ecbuild/bin:${PATH}
 
-ARG ECKIT_VERSION=1.10.1
+ARG ECKIT_VERSION=1.17.1
 RUN cd /tmp && \
     wget -q https://github.com/ecmwf/eckit/archive/${ECKIT_VERSION}.tar.gz && \
     tar xzf ${ECKIT_VERSION}.tar.gz && \
@@ -24,12 +24,11 @@ RUN cd /tmp && \
 
 
 # patch atlas: add missing include <string>
-ARG ATLAS_VERSION=0.20.1
+ARG ATLAS_VERSION=0.26.0
 RUN cd /tmp && \
     wget -q https://github.com/ecmwf/atlas/archive/${ATLAS_VERSION}.tar.gz && \
     tar xzf ${ATLAS_VERSION}.tar.gz && \
     cd atlas-${ATLAS_VERSION} && \
-    sed -i '13 i #include <string>' ./src/atlas/grid/Spacing.h && \
     mkdir build && cd build && \
     ecbuild .. && \
     make -j$(nproc) install && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 LABEL maintainer="Felix Thaler <thaler@cscs.ch>"
 
 RUN apt-get update -qq && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 LABEL maintainer="Felix Thaler <thaler@cscs.ch>"
 
 RUN apt-get update -qq && \
@@ -6,7 +6,6 @@ RUN apt-get update -qq && \
         build-essential \
         libboost-all-dev \
         ccache \
-        cmake \
         wget \
         git \
         tar \
@@ -16,5 +15,17 @@ RUN apt-get update -qq && \
         cowsay && \
     ln -s /usr/games/cowsay /usr/bin/cowsay && \
     rm -rf /var/lib/apt/lists/*
+
+# cmake version 3.16.3 is the default in ubuntu 20.04
+ARG CMAKE_VERSION=3.16.3
+# note: source name scheme changed with version 3.20 (linux instad of Linux)
+RUN cd /tmp && \
+    VNUM=$(echo ${CMAKE_VERSION} | awk -F \. {'print $1*1000+$2'}) && \
+    LNAME=$([ ${VNUM} -gt 3019 ] && echo "linux" || echo "Linux") && \
+    SRC="cmake-${CMAKE_VERSION}-${LNAME}-x86_64" && \
+    wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${SRC}.tar.gz && \
+    tar xzf ${SRC}.tar.gz && \
+    cp -r ${SRC}/bin ${SRC}/share /usr/local/ && \
+    rm -rf *
 
 CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
- For GHEX we need an up-to-date cmake version (>= 3.17)
    - added a custom cmake installation in the base container
    - build instructions now request cmake 3.21.2 (this can be downgraded if needed)
- Atlas container is patched (bug in atlas: missing include)