### PR TITLE
Updated HIP/ROCm

### DIFF
--- a/hip/Dockerfile
+++ b/hip/Dockerfile
@@ -3,10 +3,10 @@ ARG BASE
 FROM ${REPOSITORY}:${BASE}
 LABEL maintainer="Felix Thaler <thaler@cscs.ch>"
 
-# from https://docs.amd.com/bundle/ROCm-Installation-Guide-v5.1.1/page/How_to_Install_ROCm.html
-RUN wget https://repo.radeon.com/amdgpu-install/22.10.1/ubuntu/focal/amdgpu-install_22.10.1.50101-1_all.deb && \
+# from https://docs.amd.com/bundle/ROCm-Installation-Guide-v5.4/page/How_to_Install_ROCm.html
+RUN wget https://repo.radeon.com/amdgpu-install/22.40/ubuntu/jammy/amdgpu-install_5.4.50401-1_all.deb && \
     apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ./amdgpu-install_22.10.1.50101-1_all.deb && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ./amdgpu-install_5.4.50401-1_all.deb && \
     apt-get update -qq && \
     amdgpu-install -y --usecase=rocm,hip --no-dkms && \
     rm -rf /var/lib/apt/lists/*

--- a/hip/Dockerfile
+++ b/hip/Dockerfile
@@ -3,12 +3,13 @@ ARG BASE
 FROM ${REPOSITORY}:${BASE}
 LABEL maintainer="Felix Thaler <thaler@cscs.ch>"
 
-RUN wget https://repo.radeon.com/amdgpu-install/21.40/ubuntu/focal/amdgpu-install-21.40.40500-1_all.deb && \
+# from https://docs.amd.com/bundle/ROCm-Installation-Guide-v5.1.1/page/How_to_Install_ROCm.html
+RUN wget https://repo.radeon.com/amdgpu-install/22.10.1/ubuntu/focal/amdgpu-install_22.10.1.50101-1_all.deb && \
     apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ./amdgpu-install-21.40.40500-1_all.deb && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ./amdgpu-install_22.10.1.50101-1_all.deb && \
     apt-get update -qq && \
     amdgpu-install -y --usecase=rocm,hip --no-dkms && \
     rm -rf /var/lib/apt/lists/*
 
-ENV ROCM_PATH=/opt/rocm-4.5.0
+ENV ROCM_PATH=/opt/rocm
 ENV PATH=${ROCM_PATH}/bin:${PATH} CXX=${ROCM_PATH}/bin/hipcc


### PR DESCRIPTION
Use more recent ROCm 5.1. Previous installation package seems to be broken now (missing hipcc).