### PR TITLE
Use Boost 1.79

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,7 +4,6 @@ LABEL maintainer="Felix Thaler <thaler@cscs.ch>"
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
         build-essential \
-        libboost-all-dev \
         ccache \
         wget \
         git \
@@ -16,8 +15,18 @@ RUN apt-get update -qq && \
     ln -s /usr/games/cowsay /usr/bin/cowsay && \
     rm -rf /var/lib/apt/lists/*
 
+ARG BOOST_VERSION=1.79.0
+RUN cd /tmp && \
+    BOOST_VERSION_UNDERLINE=$(echo ${BOOST_VERSION} | sed 's/\./_/g') && \
+    wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERLINE}.tar.gz && \
+    tar xzf boost_${BOOST_VERSION_UNDERLINE}.tar.gz && \
+    cd boost_${BOOST_VERSION_UNDERLINE} && \
+    ./bootstrap.sh && \
+    ./b2 install && \
+    rm -rf /tmp/boost_*
+
 ARG CMAKE_VERSION=3.22.1
-# note: source name scheme changed with version 3.20 (linux instad of Linux)
+# note: source name scheme changed with version 3.20 (linux instead of Linux)
 RUN cd /tmp && \
     VNUM=$(echo ${CMAKE_VERSION} | awk -F \. {'print $1*1000+$2'}) && \
     LNAME=$([ ${VNUM} -gt 3019 ] && echo "linux" || echo "Linux") && \


### PR DESCRIPTION
Boost version 1.71 available in the Ubuntu 20.04 repository does not seem to be compatible with Clang 14 + CUDA.