### PR TITLE
Support for Several ROCm Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,7 @@ jobs:
     strategy:
       matrix:
         base: [base]
+        version: ["6.2.2"]
     steps:
     - uses: actions/checkout@v2
     - name: Free Disk Space (Ubuntu)
@@ -159,17 +160,18 @@ jobs:
         docker build
         --progress=plain
         --cache-from $CR_REPOSITORY:${{ matrix.base }}
-        --cache-from $CR_REPOSITORY:${{ matrix.base }}-rocm-6.2
+        --cache-from $CR_REPOSITORY:${{ matrix.base }}-rocm-${{ matrix.version }}
         --build-arg BUILDKIT_INLINE_CACHE=1
-        --tag $CR_REPOSITORY:${{ matrix.base }}-rocm-6.2
+        --tag $CR_REPOSITORY:${{ matrix.base }}-rocm-${{ matrix.version }}
         --build-arg REPOSITORY=$CR_REPOSITORY
         --build-arg BASE=${{ matrix.base }}
+        --build-arg ROCM_VERSION=${{ matrix.version }}
         hip
     - name: Push
       if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository == 'GridTools/gridtools-docker' }}
       run: >
         echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin &&
-        docker push $CR_REPOSITORY:${{ matrix.base }}-rocm-6.2 &&
+        docker push $CR_REPOSITORY:${{ matrix.base }}-rocm-${{ matrix.version }} &&
         docker logout ghcr.io
 
   hpx:

--- a/hip/Dockerfile
+++ b/hip/Dockerfile
@@ -3,14 +3,18 @@ ARG BASE
 FROM ${REPOSITORY}:${BASE}
 LABEL maintainer="Felix Thaler <thaler@cscs.ch>"
 
-# NOTE: If you change the ROCm version here, also change it in the build.yml to avoid overwriting the old image,
-# see https://github.com/GridTools/gridtools-docker/issues/97.
-RUN wget https://repo.radeon.com/amdgpu-install/6.2.1/ubuntu/noble/amdgpu-install_6.2.60201-1_all.deb && \
+ARG ROCM_VERSION
+ENV ROCM_VERSION ${ROCM_VERSION}
+
+# NOTE: the newest ROCm release should allow to also install older releases. However, older releases
+# might not necessarily be available on the current Ubuntu version. For example, on Ubuntu 24.04,
+# ROCm 6.2 is currently the only available release.
+RUN wget https://repo.radeon.com/amdgpu-install/6.2.2/ubuntu/noble/amdgpu-install_6.2.60202-1_all.deb && \
     apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ./amdgpu-install_6.2.60201-1_all.deb && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ./amdgpu-install_6.2.60202-1_all.deb && \
     apt-get update -qq && \
-    amdgpu-install -y --usecase=rocm,hip --no-dkms && \
+    amdgpu-install -y --usecase=hiplibsdk --no-dkms --rocmrelease=${ROCM_VERSION} && \
     rm -rf /var/lib/apt/lists/*
 
-ENV ROCM_PATH=/opt/rocm
+ENV ROCM_PATH=/opt/rocm-${ROCM_VERSION}
 ENV PATH=${ROCM_PATH}/bin:${PATH} CXX=${ROCM_PATH}/bin/hipcc


### PR DESCRIPTION
Allow to build multiple ROCm versions. Note: currently there is only one ROCm version for Ubuntu 24.04 available, so only this one is built.